### PR TITLE
Interacting with Input Fields practice.

### DIFF
--- a/tests/inputFields.spec.ts
+++ b/tests/inputFields.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach( async({page}) => {
+  await page.goto('/')
+  await page.getByTitle("pettypes").click()
+  await expect(page.locator('h2')).toHaveText('Pet Types')
+})
+
+test.describe("Interacting with Input Fields practice", async () => {
+    test('Update pet type', async ({page}) => {
+        // Change the pet type name from "cat" to "rabbit" and click "Update" button
+        await page.getByRole('row', { name: 'cat Edit Delete' }).getByRole('button', {name: 'Edit'}).click()
+        await expect(page.locator('h2')).toHaveText('Edit Pet Type')
+        const nameField = page.getByRole('textbox')
+        await nameField.click()
+        await nameField.clear()
+        await nameField.fill('rabbit')
+        const updateNameButton = page.getByRole('button', {name:"Update"})
+        await updateNameButton.click();
+
+        //Add the assertion that the first pet type in the list of types has an edited value "rabbit" 
+        const firstPetInTheList = page.locator('[id="0"]')
+        await expect(firstPetInTheList).toHaveValue("rabbit");
+        
+        //Click on "Edit" button for the same "rabbit" pet type
+        await page.getByRole('row', { name: 'rabbit Edit Delete' }).getByRole('button', {name: 'Edit'}).click()
+
+        // Change the pet type name back from "rabbit" to "cat" and click "Update" button
+        await nameField.click()
+        await nameField.clear()
+        await nameField.fill('cat')
+        await updateNameButton.click();
+
+        //Add the assertion that the first pet type in the list of names has a value "cat" 
+        await expect(firstPetInTheList).toHaveValue("cat")
+    });
+
+    test('Cancel pet type update', async ({page}) => {
+        // Click on "Edit" button for the "dog" pet type
+        await page.getByRole('row', { name: 'dog Edit Delete' }).getByRole('button', {name: 'Edit'}).click()
+
+        // Type the new pet type name "moose"
+        const nameField = page.getByRole('textbox')
+        await nameField.click()
+        await nameField.clear()
+        await nameField.fill('moose')
+
+        // Add assertion the value "moose" is displayed in the input field of the "Edit Pet Type" page
+        const nameFieldValue = await nameField.inputValue();
+        expect(nameFieldValue).toEqual('moose');
+
+        // Cancel the changes and verify that the "dog" value is still displayed in the list of pet types
+        await page.getByRole('button', {name:"Cancel"}).click()
+        await expect(page.locator('[id="1"]')).toHaveValue("dog");
+    });
+
+    test('Pet type name is required validation', async ({page}) => {
+        // Click on "Edit" button for the "lizard" pet type
+        await page.getByRole('row', { name: 'lizard Edit Delete' }).getByRole('button', {name: 'Edit'}).click()
+
+        // On the Edit Pet Type page, verify validation message when Name field is empty
+        const nameField = page.getByRole('textbox')
+        await nameField.click()
+        await nameField.clear()
+        const message = page.getByText('Name is required')
+        expect(message).toHaveText('Name is required');
+        await page.getByRole('button', {name:"Update"}).click()
+
+        // Verify that "Edit Pet Type" page is still displayed after submitting empty value
+        await expect(page.locator('h2')).toHaveText('Edit Pet Type')
+        await page.getByRole('button', {name:"Cancel"}).click()
+
+        // Verify that "Pet Types" page is displayed when changes are cancelled
+        await expect(page.locator('h2')).toHaveText('Pet Types')
+    });
+
+})

--- a/tests/inputFields.spec.ts
+++ b/tests/inputFields.spec.ts
@@ -1,35 +1,36 @@
 import { test, expect } from '@playwright/test';
 
 test.beforeEach( async({page}) => {
-  await page.goto('/')
-  await page.getByTitle("pettypes").click()
-  await expect(page.locator('h2')).toHaveText('Pet Types')
+  await page.goto('/');
+  await page.getByRole('link', {name:"Pet Types"}).click();
+  await expect(page.getByRole('heading')).toHaveText('Pet Types');
 })
 
 test.describe("Interacting with Input Fields practice", async () => {
     test('Update pet type', async ({page}) => {
         // Change the pet type name from "cat" to "rabbit" and click "Update" button
-        await page.getByRole('row', { name: 'cat Edit Delete' }).getByRole('button', {name: 'Edit'}).click()
-        await expect(page.locator('h2')).toHaveText('Edit Pet Type')
-        const nameField = page.getByRole('textbox')
-        await nameField.click()
-        await nameField.clear()
-        await nameField.fill('rabbit')
-        const updateNameButton = page.getByRole('button', {name:"Update"})
-        await updateNameButton.click();
+        await page.getByRole('row', { name: 'cat' }).getByRole('button', {name: 'Edit'}).click();
+
+        await expect(page.getByRole('heading')).toHaveText('Edit Pet Type');
+        const nameField = page.getByRole('textbox');
+        await nameField.click();
+        await nameField.clear();
+        await nameField.fill('rabbit');
+        await page.getByRole('button', {name:"Update"}).click();
+        
 
         //Add the assertion that the first pet type in the list of types has an edited value "rabbit" 
-        const firstPetInTheList = page.locator('[id="0"]')
+        const firstPetInTheList = page.locator('[id="0"]');
         await expect(firstPetInTheList).toHaveValue("rabbit");
         
         //Click on "Edit" button for the same "rabbit" pet type
-        await page.getByRole('row', { name: 'rabbit Edit Delete' }).getByRole('button', {name: 'Edit'}).click()
+        await page.getByRole('row', { name: 'rabbit' }).getByRole('button', {name: 'Edit'}).click();
 
         // Change the pet type name back from "rabbit" to "cat" and click "Update" button
-        await nameField.click()
-        await nameField.clear()
-        await nameField.fill('cat')
-        await updateNameButton.click();
+        await nameField.click();
+        await nameField.clear();
+        await nameField.fill('cat');
+        await page.getByRole('button', {name:"Update"}).click();
 
         //Add the assertion that the first pet type in the list of names has a value "cat" 
         await expect(firstPetInTheList).toHaveValue("cat")
@@ -37,7 +38,7 @@ test.describe("Interacting with Input Fields practice", async () => {
 
     test('Cancel pet type update', async ({page}) => {
         // Click on "Edit" button for the "dog" pet type
-        await page.getByRole('row', { name: 'dog Edit Delete' }).getByRole('button', {name: 'Edit'}).click()
+        await page.getByRole('row', { name: 'dog' }).getByRole('button', {name: 'Edit'}).click()
 
         // Type the new pet type name "moose"
         const nameField = page.getByRole('textbox')
@@ -56,22 +57,21 @@ test.describe("Interacting with Input Fields practice", async () => {
 
     test('Pet type name is required validation', async ({page}) => {
         // Click on "Edit" button for the "lizard" pet type
-        await page.getByRole('row', { name: 'lizard Edit Delete' }).getByRole('button', {name: 'Edit'}).click()
+        await page.getByRole('row', { name: 'lizard' }).getByRole('button', {name: 'Edit'}).click()
 
         // On the Edit Pet Type page, verify validation message when Name field is empty
         const nameField = page.getByRole('textbox')
         await nameField.click()
         await nameField.clear()
-        const message = page.getByText('Name is required')
-        expect(message).toHaveText('Name is required');
+        await expect(page.locator('.help-block')).toHaveText('Name is required');
         await page.getByRole('button', {name:"Update"}).click()
 
         // Verify that "Edit Pet Type" page is still displayed after submitting empty value
-        await expect(page.locator('h2')).toHaveText('Edit Pet Type')
+        await expect(page.getByRole('heading')).toHaveText('Edit Pet Type')
         await page.getByRole('button', {name:"Cancel"}).click()
 
         // Verify that "Pet Types" page is displayed when changes are cancelled
-        await expect(page.locator('h2')).toHaveText('Pet Types')
+        await expect(page.getByRole('heading')).toHaveText('Pet Types')
     });
 
 })


### PR DESCRIPTION
Hello!
I have a question related to the Pet Types page. There is a table with all added pet names, I just wondered if there is a better way how to extract the pet name to interact with. I used a hardcoded values, something like that:

 // Click on "Edit" button for the "dog" pet type
        await page.getByRole('row', { name: 'dog Edit Delete' }).getByRole('button', {name: 'Edit'}).click()

// Verify that the "dog" value is still displayed in the list of pet types
       await expect(page.locator('[id="1"]')).toHaveValue("dog");

I tried to extract the pet name from the table using the innerText() method, since the pet names are not a part of the DOM as I see, but only the button titles returned: 
await page.locator("tr").nth(2).innerText()

Look forward for your feedback.
Thank you in advance.
